### PR TITLE
Fix and Feature enhancement

### DIFF
--- a/autoload/netrw.vim
+++ b/autoload/netrw.vim
@@ -6189,6 +6189,7 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <nowait> v	:call <SID>NetrwSplit(5)<cr>
    nnoremap <buffer> <silent> <nowait> x	:<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),0),0)"<cr>
    nnoremap <buffer> <silent> <nowait> X	:<c-u>call <SID>NetrwLocalExecute(expand("<cword>"))"<cr>
+   nnoremap <buffer> <silent> <nowait> y	:<c-u>call setreg(v:register,<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),0))"<cr>
 "   " local insert-mode maps
 "   inoremap <buffer> <silent> <nowait> a	<c-o>:call <SID>NetrwHide(1)<cr>
 "   inoremap <buffer> <silent> <nowait> c	<c-o>:exe "NetrwKeepj lcd ".fnameescape(b:netrw_curdir)<cr>
@@ -6362,6 +6363,7 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <nowait> U	:<c-u>call <SID>NetrwBookHistHandler(5,b:netrw_curdir)<cr>
    nnoremap <buffer> <silent> <nowait> v	:call <SID>NetrwSplit(2)<cr>
    nnoremap <buffer> <silent> <nowait> x	:<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord()),1)<cr>
+   nnoremap <buffer> <silent> <nowait> y	:<c-u>call setreg(v:register,<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord(),0))"<cr>
 "   " remote insert-mode maps
 "   inoremap <buffer> <silent> <nowait> <cr>	<c-o>:call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord()))<cr>
 "   inoremap <buffer> <silent> <nowait> <c-l>	<c-o>:call <SID>NetrwRefresh(0,<SID>NetrwBrowseChgDir(0,'./'))<cr>

--- a/autoload/netrw.vim
+++ b/autoload/netrw.vim
@@ -4905,7 +4905,7 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
     call remove(w:netrw_treedict,treedir)
 "    call Decho("tree-list: removed     entry<".treedir."> from treedict",'~'.expand("<slnum>"))
 "    call Decho("tree-list: yielding treedict<".string(w:netrw_treedict).">",'~'.expand("<slnum>"))
-    let dirname= w:netrw_treetop
+    let dirname=treedir
    else
     " go down one directory
     let dirname= substitute(treedir,'/*$','/','')


### PR DESCRIPTION
# Bug fix
Here are my Environment details:
OS: MacOS Sierra
Vim Version: NVIM v0.2.2
Netrw version: 162j

Steps to reproduce the bug:
1. Open Netrw
2. Change to Treelist view
3. "Enter" root folder
4. Go to any subfolder, suppose "FolderA" and press "Enter"
5. Press 'x' on the opened subfolder i.e. "FolderA"
6. Notice instead of opening "FolderA" in finder, netrw opens the root folder in finder

I debugged the netrw code and found the bug to be because of dirname variable being set to netrw_treetop instead of treedir in NetrwBrowseChgDir() function.

# Feature
Adds a feature to copy path of the selected folder/file to current register on 'y' button press.